### PR TITLE
【アイテム廃棄機能】discard item の mutation・queryを追加

### DIFF
--- a/app/graphql/input_types/discard_item_input_type.rb
+++ b/app/graphql/input_types/discard_item_input_type.rb
@@ -1,0 +1,5 @@
+class InputTypes::DiscardItemInputType < Types::BaseInputObject
+  graphql_name 'DiscardItemAttributes'
+
+  argument :item_id, ID, required: true
+end

--- a/app/graphql/input_types/restore_item_input_type.rb
+++ b/app/graphql/input_types/restore_item_input_type.rb
@@ -1,0 +1,5 @@
+class InputTypes::RestoreItemInputType < Types::BaseInputObject
+  graphql_name 'RestoreItemAttributes'
+
+  argument :item_id, ID, required: true
+end

--- a/app/graphql/mutations/discard_item.rb
+++ b/app/graphql/mutations/discard_item.rb
@@ -1,0 +1,18 @@
+module Mutations
+  class DiscardItem < Mutations::BaseMutation
+    field :item, ObjectTypes::Item, null: false
+    argument :params, InputTypes::DiscardItemInputType, required: true
+
+    def resolve(params:)
+      item = Item.find params.item_id
+      item.update!(state: :discarded)
+
+      {
+        item: item
+      }
+
+    rescue => e
+      GraphQL::ExecutionError.new(e.message)
+    end
+  end
+end

--- a/app/graphql/mutations/restore_item.rb
+++ b/app/graphql/mutations/restore_item.rb
@@ -1,0 +1,18 @@
+module Mutations
+  class RestoreItem < Mutations::BaseMutation
+    field :item, ObjectTypes::Item, null: false
+    argument :params, InputTypes::RestoreItemInputType, required: true
+
+    def resolve(params:)
+      item = Item.find params.item_id
+      item.update!(state: :active)
+
+      {
+        item: item
+      }
+
+    rescue => e
+      GraphQL::ExecutionError.new(e.message)
+    end
+  end
+end

--- a/app/graphql/queries/discarded_items.rb
+++ b/app/graphql/queries/discarded_items.rb
@@ -1,0 +1,9 @@
+module Queries
+  class DiscardedItems < Queries::BaseQuery
+    type ObjectTypes::Item.connection_type, null: false
+
+    def resolve
+      ::Item.discarded.order(id: "DESC")
+    end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -5,5 +5,7 @@ module Types
     field :delete_item, mutation: Mutations::DeleteItem
     field :create_item_stock_management, mutation: Mutations::CreateItemStockManagement
     field :update_item_stock_management, mutation: Mutations::UpdateItemStockManagement
+    field :discard_item, mutation: Mutations::DiscardItem
+    field :restore_item, mutation: Mutations::RestoreItem
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -9,5 +9,6 @@ module Types
     field :categories, resolver: Queries::Categories
     field :item_stock_management, resolver: Queries::ItemStockManagement
     field :item_stock_managements, resolver: Queries::ItemStockManagements
+    field :discarded_items, resolver: Queries::DiscardedItems
   end
 end


### PR DESCRIPTION
## 変更内容
- アイテムのステータス変更Mutationを追加
  - active || discarded
- 廃棄アイテム一覧クエリを追加
 
## 確認事項
#### ローカル
- [x] 以下クエリを実行して、廃棄アイテム一覧が取得できること

```
query {
  discardedItems {
    nodes {
      id
    }
  }
}
```

- [x] 以下Mutationを実行して、ステータスの変更ができること

```
mutation {
  discardItem(input: {params: {itemId: 54}}){
    item {
      id
    }
  }
}
```

```
mutation {
  restoreItem(input: {params: {itemId: 54}}){
    item {
      id
    }
  }
}
```